### PR TITLE
Update lambda node version from 16 to latest (20)

### DIFF
--- a/terraform/ui/lambda.tf
+++ b/terraform/ui/lambda.tf
@@ -6,7 +6,7 @@ resource "aws_lambda_function" "ui" {
   filename         = "${path.module}/main.js.zip"
   handler          = "main.handler"
   source_code_hash = data.archive_file.ui.output_base64sha256
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs20.x"
   publish          = true
   lifecycle {
     ignore_changes = [source_code_hash]


### PR DESCRIPTION
Node version 16 is no longer supported on AWS, the terraform lambda has been updated to use Node 20 instead.

This has been tested locally to have no issues. Manual analysis of the lambda code found here https://github.com/IHTSDO/snap2snomed/blob/cb6c88ad71bca1887ff12a6479e878b63e18b95c/terraform/ui/main.js#L24 against the changelogs show no breaking changes either https://github.com/nodejs/node/tree/main/doc/changelogs