### PR TITLE
Add AWS Secrets manager secret to hold sensitive data

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -107,7 +107,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.19.2</version> <!-- force version for CVE-2025-52999; remove when io.jsonwebtoken:jjwt-jackson:jar updates this -->
+        <version>2.21.1</version> <!-- force version for CVE-2025-52999; remove when io.jsonwebtoken:jjwt-jackson:jar updates this -->
       </dependency>
       <dependency>
         <groupId>commons-beanutils</groupId>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ pool:
 variables:
   mavenCache: $(Pipeline.Workspace)/.m2/repository
   mavenOptions: '-Dmaven.repo.local=$(mavenCache)'
-  trivyVersion: 0.27.1
+  trivyVersion: 0.69.3
 
 stages:
   - stage: build

--- a/terraform/api/api.tf
+++ b/terraform/api/api.tf
@@ -28,11 +28,11 @@ resource "aws_ecs_task_definition" "api" {
     secrets = [
       {
         name      = "spring.datasource.username"
-        valueFrom = "${aws_rds_cluster.api.master_user_secret[0].secret_arn}:username::"
+        valueFrom = "${try(aws_rds_cluster.api.master_user_secret[0].secret_arn, "")}:username::"
       },
       {
         name      = "spring.datasource.password"
-        valueFrom = "${aws_rds_cluster.api.master_user_secret[0].secret_arn}:password::"
+        valueFrom = "${try(aws_rds_cluster.api.master_user_secret[0].secret_arn, "")}:password::"
       },
       {
         name      = "snap2snomed.security.clientId"
@@ -116,14 +116,14 @@ data "aws_iam_policy_document" "api" {
       "logs:CreateLogStream",
       "logs:PutLogEvents"
     ]
-    resources = [
+    resources = compact([
       aws_secretsmanager_secret.api.arn,
       aws_secretsmanager_secret.app_secrets.arn,
-      aws_rds_cluster.api.master_user_secret[0].secret_arn,
+      try(aws_rds_cluster.api.master_user_secret[0].secret_arn, null),
       aws_kms_key.api.arn,
       aws_cloudwatch_log_group.api.arn,
       "${aws_cloudwatch_log_group.api.arn}:log-stream:*"
-    ]
+    ])
   }
 }
 

--- a/terraform/api/api.tf
+++ b/terraform/api/api.tf
@@ -23,7 +23,25 @@ resource "aws_ecs_task_definition" "api" {
     },
     environment = [
       for variable in local.api_ecs_environment : variable
-      if variable.value != "" 
+      if variable.value != ""
+    ],
+    secrets = [
+      {
+        name      = "spring.datasource.username"
+        valueFrom = "${aws_secretsmanager_secret.app_secrets.arn}:database_username::"
+      },
+      {
+        name      = "spring.datasource.password"
+        valueFrom = "${aws_secretsmanager_secret.app_secrets.arn}:database_password::"
+      },
+      {
+        name      = "snap2snomed.security.clientId"
+        valueFrom = "${aws_secretsmanager_secret.app_secrets.arn}:client_id::"
+      },
+      {
+        name      = "sentry.dsn"
+        valueFrom = "${aws_secretsmanager_secret.app_secrets.arn}:sentry_dsn::"
+      }
     ]
     logConfiguration = {
       logDriver = "awslogs",
@@ -100,6 +118,7 @@ data "aws_iam_policy_document" "api" {
     ]
     resources = [
       aws_secretsmanager_secret.api.arn,
+      aws_secretsmanager_secret.app_secrets.arn,
       aws_kms_key.api.arn,
       aws_cloudwatch_log_group.api.arn,
       "${aws_cloudwatch_log_group.api.arn}:log-stream:*"
@@ -129,6 +148,22 @@ resource "aws_secretsmanager_secret_version" "api" {
   secret_string = jsonencode({
     username = var.registry_username,
     password = var.registry_password
+  })
+}
+
+resource "aws_secretsmanager_secret" "app_secrets" {
+  name                    = format("%s-AppSecrets", replace(var.host_name, "/[.]/", "-"))
+  kms_key_id              = aws_kms_key.api.id
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "app_secrets" {
+  secret_id = aws_secretsmanager_secret.app_secrets.id
+  secret_string = jsonencode({
+    database_username = var.database_user,
+    database_password = var.database_password,
+    client_id         = var.client_id,
+    sentry_dsn        = var.sentry_dsn
   })
 }
 

--- a/terraform/api/api.tf
+++ b/terraform/api/api.tf
@@ -28,11 +28,11 @@ resource "aws_ecs_task_definition" "api" {
     secrets = [
       {
         name      = "spring.datasource.username"
-        valueFrom = "${aws_secretsmanager_secret.app_secrets.arn}:database_username::"
+        valueFrom = "${aws_rds_cluster.api.master_user_secret[0].secret_arn}:username::"
       },
       {
         name      = "spring.datasource.password"
-        valueFrom = "${aws_secretsmanager_secret.app_secrets.arn}:database_password::"
+        valueFrom = "${aws_rds_cluster.api.master_user_secret[0].secret_arn}:password::"
       },
       {
         name      = "snap2snomed.security.clientId"
@@ -119,6 +119,7 @@ data "aws_iam_policy_document" "api" {
     resources = [
       aws_secretsmanager_secret.api.arn,
       aws_secretsmanager_secret.app_secrets.arn,
+      aws_rds_cluster.api.master_user_secret[0].secret_arn,
       aws_kms_key.api.arn,
       aws_cloudwatch_log_group.api.arn,
       "${aws_cloudwatch_log_group.api.arn}:log-stream:*"
@@ -160,10 +161,8 @@ resource "aws_secretsmanager_secret" "app_secrets" {
 resource "aws_secretsmanager_secret_version" "app_secrets" {
   secret_id = aws_secretsmanager_secret.app_secrets.id
   secret_string = jsonencode({
-    database_username = var.database_user,
-    database_password = var.database_password,
-    client_id         = var.client_id,
-    sentry_dsn        = var.sentry_dsn
+    client_id  = var.client_id,
+    sentry_dsn = var.sentry_dsn
   })
 }
 

--- a/terraform/api/db.tf
+++ b/terraform/api/db.tf
@@ -6,7 +6,8 @@ resource "aws_rds_cluster" "api" {
   backup_retention_period         = var.database_backup_retention_period
   database_name                   = replace(var.host_name, "/[.]/", "")
   master_username                 = var.database_user
-  master_password                 = var.database_password
+  manage_master_user_password     = true
+  master_user_secret_kms_key_id   = aws_kms_key.api.id
   db_subnet_group_name            = aws_db_subnet_group.api.name
   vpc_security_group_ids          = [aws_security_group.api_db.id,aws_security_group.jumpbox_db.id]
   final_snapshot_identifier       = "ci-aurora-cluster-backup-final"

--- a/terraform/api/db.tf
+++ b/terraform/api/db.tf
@@ -16,15 +16,6 @@ resource "aws_rds_cluster" "api" {
   }
 }
 
-resource "aws_secretsmanager_secret_rotation" "db" {
-  count              = length(aws_rds_cluster.api.master_user_secret) > 0 ? 1 : 0
-  secret_id          = aws_rds_cluster.api.master_user_secret[0].secret_arn
-  rotate_immediately = false
-
-  rotation_rules {
-    automatically_after_days = 30
-  }
-}
 
 resource "aws_rds_cluster_instance" "api" {
   cluster_identifier      = aws_rds_cluster.api.id

--- a/terraform/api/db.tf
+++ b/terraform/api/db.tf
@@ -16,6 +16,15 @@ resource "aws_rds_cluster" "api" {
   }
 }
 
+resource "aws_secretsmanager_secret_rotation" "db" {
+  secret_id          = aws_rds_cluster.api.master_user_secret[0].secret_arn
+  rotate_immediately = false
+
+  rotation_rules {
+    automatically_after_days = 30
+  }
+}
+
 resource "aws_rds_cluster_instance" "api" {
   cluster_identifier      = aws_rds_cluster.api.id
   engine                  = "aurora-mysql"

--- a/terraform/api/db.tf
+++ b/terraform/api/db.tf
@@ -17,6 +17,7 @@ resource "aws_rds_cluster" "api" {
 }
 
 resource "aws_secretsmanager_secret_rotation" "db" {
+  count              = length(aws_rds_cluster.api.master_user_secret) > 0 ? 1 : 0
   secret_id          = aws_rds_cluster.api.master_user_secret[0].secret_arn
   rotate_immediately = false
 

--- a/terraform/api/locals.tf
+++ b/terraform/api/locals.tf
@@ -17,28 +17,12 @@ locals {
       value = "org.hibernate.dialect.MariaDBDialect"
     },
     {
-      name  = "spring.datasource.username",
-      value = aws_rds_cluster.api.master_username
-    },
-    {
-      name  = "spring.datasource.password",
-      value = var.database_password
-    },
-    {
-      name  = "snap2snomed.security.clientId",
-      value = var.client_id
-    },
-    {
       name  = "spring.security.oauth2.resourceserver.jwt.issuer-uri",
       value = "https://${var.jwt_issuer-uri}"
     },
     {
       name  = "snap2snomed.swagger.applicationVersion",
       value = var.application_version
-    },
-    {
-      name  = "sentry.dsn",
-      value = var.sentry_dsn
     },
     {
       name  = "sentry.environment",

--- a/terraform/api/main.tf
+++ b/terraform/api/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "4.58.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/terraform/api/variables.tf
+++ b/terraform/api/variables.tf
@@ -83,6 +83,7 @@ variable "application_version" {
 variable "sentry_dsn" {
   description = "DSN to raise errors with Sentry"
   type        = string
+  sensitive   = true
 }
 
 variable "sentry_environment" {

--- a/terraform/api/variables.tf
+++ b/terraform/api/variables.tf
@@ -44,11 +44,6 @@ variable "database_user" {
   default     = "snap2snomed"
 }
 
-variable "database_password" {
-  description = "Password for accessing the database"
-  type        = string
-  sensitive   = true
-}
 
 variable "zone_id" {
   description = "Route 53 zone ID"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "4.58.0"
+      version = "~> 5.0"
     }
     archive = {
       source = "hashicorp/archive"
@@ -36,7 +36,6 @@ module "api" {
   registry_password                = var.api_registry_password
   cpu                              = var.api_cpu
   memory                           = var.api_memory
-  database_password                = var.api_database_password
   zone_id                          = data.aws_route53_zone.app.zone_id
   host_name                        = var.api_host_name
   host_name_si                     = var.api_host_name_si

--- a/terraform/ui/main.tf
+++ b/terraform/ui/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = "4.58.0"
+      version               = "~> 5.0"
       configuration_aliases = [aws.us-east-1]
     }
     archive = {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -40,11 +40,6 @@ variable "api_memory" {
   default     = 8192
 }
 
-variable "api_database_password" {
-  description = "Password for accessing the database"
-  type        = string
-  sensitive   = true
-}
 
 variable "domain" {
   description = "Second-level domain used for the zone"


### PR DESCRIPTION
# Pull Request Template

## Description

Move sensitive data to AWS Secrets Manager secrets so they are not plaintext in the ECS Task definitions

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Test on DEV first