### PR TITLE
Prod snap2snomed.app is not used anymore - this should remove all ref…

### DIFF
--- a/terraform/ui/cert.tf
+++ b/terraform/ui/cert.tf
@@ -19,13 +19,13 @@ resource "aws_acm_certificate" "ui_si" {
 }
 
 resource "aws_route53_record" "ui_validation" {
-  for_each = {
-    for dvo in aws_acm_certificate.ui.domain_validation_options : dvo.domain_name => {
+  for_each = length(aws_acm_certificate.ui) > 0 ? {
+    for dvo in aws_acm_certificate.ui[0].domain_validation_options : dvo.domain_name => {
       name   = dvo.resource_record_name
       record = dvo.resource_record_value
       type   = dvo.resource_record_type
     }
-  }
+  } : {}
   allow_overwrite = true
   name            = each.value.name
   records         = [each.value.record]
@@ -35,7 +35,8 @@ resource "aws_route53_record" "ui_validation" {
 }
 
 resource "aws_acm_certificate_validation" "ui" {
+  count                   = length(aws_acm_certificate.ui)
   provider                = aws.us-east-1
-  certificate_arn         = aws_acm_certificate.ui.arn
+  certificate_arn         = aws_acm_certificate.ui[0].arn
   validation_record_fqdns = [for record in aws_route53_record.ui_validation : record.fqdn]
 }

--- a/terraform/ui/cloudfront.tf
+++ b/terraform/ui/cloudfront.tf
@@ -13,7 +13,7 @@ resource "aws_cloudfront_distribution" "ui" {
   default_root_object = "index.html"
   aliases             = [terraform.workspace == "prod" ? var.host_name_si : var.host_name]
   viewer_certificate {
-    acm_certificate_arn      = terraform.workspace == "prod" ? aws_acm_certificate.ui_si[0].arn : aws_acm_certificate_validation.ui.certificate_arn
+    acm_certificate_arn      = terraform.workspace == "prod" ? aws_acm_certificate.ui_si[0].arn : aws_acm_certificate_validation.ui[0].certificate_arn
     minimum_protocol_version = "TLSv1.2_2019"
     ssl_support_method       = "sni-only"
   }


### PR DESCRIPTION
More certificate fixes for Prod

We never used snap2snomed.app but snap.snomedtools.org points to it via CNAME