### PR TITLE
Make version upgrades ignorable

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -31,4 +31,22 @@ CVE-2024-38819
 CVE-2025-22235
 
 # Bug should not affect our application. Need to upgrade spring-boot to get a fix
- CVE-2025-41249
+CVE-2025-41249
+
+### This needs to be removed after terraform state update
+# libpng (OS package)
+CVE-2026-33416
+CVE-2026-33636
+
+# HAPI FHIR
+CVE-2026-33180
+CVE-2026-34359
+
+# Tomcat
+CVE-2026-24734
+
+# Spring Boot Actuator
+CVE-2026-22733
+
+# Spring Security
+CVE-2026-22732

--- a/.trivyignore
+++ b/.trivyignore
@@ -32,21 +32,3 @@ CVE-2025-22235
 
 # Bug should not affect our application. Need to upgrade spring-boot to get a fix
 CVE-2025-41249
-
-### This needs to be removed after terraform state update
-# libpng (OS package)
-CVE-2026-33416
-CVE-2026-33636
-
-# HAPI FHIR
-CVE-2026-33180
-CVE-2026-34359
-
-# Tomcat
-CVE-2026-24734
-
-# Spring Boot Actuator
-CVE-2026-22733
-
-# Spring Security
-CVE-2026-22732

--- a/terraform/api/db.tf
+++ b/terraform/api/db.tf
@@ -1,7 +1,7 @@
 resource "aws_rds_cluster" "api" {
   cluster_identifier              = replace(var.host_name, "/[.]/", "-")
   engine                          = "aurora-mysql"
-  engine_version                  = "8.0.mysql_aurora.3.08.2"
+  engine_version                  = "8.0.mysql_aurora.3.10.3"
   db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.snapdbcluster.id
   backup_retention_period         = var.database_backup_retention_period
   database_name                   = replace(var.host_name, "/[.]/", "")
@@ -9,13 +9,17 @@ resource "aws_rds_cluster" "api" {
   manage_master_user_password     = true
   master_user_secret_kms_key_id   = aws_kms_key.api.id
   db_subnet_group_name            = aws_db_subnet_group.api.name
-  vpc_security_group_ids          = [aws_security_group.api_db.id,aws_security_group.jumpbox_db.id]
+  vpc_security_group_ids          = [
+    aws_security_group.api_db.id,
+    aws_security_group.jumpbox_db.id
+  ]
   final_snapshot_identifier       = "ci-aurora-cluster-backup-final"
+
   lifecycle {
     prevent_destroy = false
+    ignore_changes  = [engine_version]
   }
 }
-
 
 resource "aws_rds_cluster_instance" "api" {
   cluster_identifier      = aws_rds_cluster.api.id

--- a/terraform/api/db.tf
+++ b/terraform/api/db.tf
@@ -16,7 +16,7 @@ resource "aws_rds_cluster" "api" {
   final_snapshot_identifier       = "ci-aurora-cluster-backup-final"
 
   lifecycle {
-    prevent_destroy = false
+    prevent_destroy = true
     ignore_changes  = [engine_version]
   }
 }


### PR DESCRIPTION
This change will make version upgrades ignorable so terraform doesn't try to install lesser version of rds
